### PR TITLE
Update runtime to Freedesktop 25.08

### DIFF
--- a/com.github.horaciodrs.tradesim.json
+++ b/com.github.horaciodrs.tradesim.json
@@ -1,10 +1,17 @@
 {
     "app-id": "com.github.horaciodrs.tradesim",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
-    "sdk": "org.gnome.Sdk",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "25.08",
     "base":"io.elementary.BaseApp",
-    "base-version": "juno-21.08",
+    "base-version": "circe-25.08",
+    "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.vala"
+    ],
+    "build-options": {
+        "prepend-path": "/usr/lib/sdk/vala/bin/",
+        "prepend-ld-library-path": "/usr/lib/sdk/vala/lib"
+    },
     "command": "com.github.horaciodrs.tradesim",
     "finish-args": [
         "--share=ipc",
@@ -14,6 +21,16 @@
     ],
     "modules": [
         {
+            "name": "libgee",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libgee/0.20/libgee-0.20.8.tar.xz",
+                    "sha256": "189815ac143d89867193b0c52b7dc31f3aa108a15f04d6b5dca2b6adfad0b0ee"
+                }
+            ]
+        },
+        {
             "name": "tradesim",
             "buildsystem": "meson",
             "sources": [
@@ -21,7 +38,16 @@
                     "type": "git",
                     "url": "https://github.com/horaciodrs/tradesim",
                     "tag": "2021.4.1"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix_appdata.patch"
                 }
+            ],
+            "post-install" : [
+                "mkdir -p /app/share/icons/hicolor/scalable/apps",
+                "mv /app/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
+                "find /app/share/icons/hicolor -type f -not -path \"*scalable*\" -not -path \"*actions*\" -name \"*.svg\" -delete"
             ]
         }
    ]

--- a/com.github.horaciodrs.tradesim.json
+++ b/com.github.horaciodrs.tradesim.json
@@ -15,8 +15,7 @@
     "command": "com.github.horaciodrs.tradesim",
     "finish-args": [
         "--share=ipc",
-        "--socket=fallback-x11",
-        "--socket=wayland",
+        "--socket=x11",
         "--talk-name=org.gtk.vfs.*"
     ],
     "modules": [

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,67 @@
+From 217b6a71d25267699e60c958e0c97c9d231cafcd Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Wed, 24 Dec 2025 01:47:05 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+---
+ data/com.github.horaciodrs.tradesim.appdata.xml.in | 34 ++++------------------------------
+ 1 file changed, 4 insertions(+), 30 deletions(-)
+
+diff --git a/data/com.github.horaciodrs.tradesim.appdata.xml.in b/data/com.github.horaciodrs.tradesim.appdata.xml.in
+index 6c92ce5..a8c2b41 100644
+--- a/data/com.github.horaciodrs.tradesim.appdata.xml.in
++++ b/data/com.github.horaciodrs.tradesim.appdata.xml.in
+@@ -1,6 +1,6 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <!-- Copyright 2020 Horacio Daniel Ros <horaciodrs@gmail.com> -->
+-<component type="desktop">
++<component type="desktop-application">
+     <id>com.github.horaciodrs.tradesim</id>
+     <metadata_license>CC0</metadata_license>
+     <project_license>GPL-3.0+</project_license>
+@@ -83,39 +83,13 @@
+     <provides>
+         <binary>com.github.horaciodrs.tradesim</binary>
+     </provides>
+-    <content_rating type="oars-1.1">
+-        <content_attribute id="violence-cartoon">none</content_attribute>
+-        <content_attribute id="violence-fantasy">none</content_attribute>
+-        <content_attribute id="violence-realistic">none</content_attribute>
+-        <content_attribute id="violence-bloodshed">none</content_attribute>
+-        <content_attribute id="violence-sexual">none</content_attribute>
+-        <content_attribute id="violence-desecration">none</content_attribute>
+-        <content_attribute id="violence-slavery">none</content_attribute>
+-        <content_attribute id="violence-worship">none</content_attribute>
+-        <content_attribute id="drugs-alcohol">none</content_attribute>
+-        <content_attribute id="drugs-narcotics">none</content_attribute>
+-        <content_attribute id="drugs-tobacco">none</content_attribute>
+-        <content_attribute id="sex-nudity">none</content_attribute>
+-        <content_attribute id="sex-themes">none</content_attribute>
+-        <content_attribute id="sex-homosexuality">none</content_attribute>
+-        <content_attribute id="sex-prostitution">none</content_attribute>
+-        <content_attribute id="sex-adultery">none</content_attribute>
+-        <content_attribute id="sex-appearance">none</content_attribute>
+-        <content_attribute id="language-profanity">none</content_attribute>
+-        <content_attribute id="language-humor">none</content_attribute>
+-        <content_attribute id="language-discrimination">none</content_attribute>
+-        <content_attribute id="social-chat">none</content_attribute>
+-        <content_attribute id="social-info">none</content_attribute>
+-        <content_attribute id="social-audio">none</content_attribute>
+-        <content_attribute id="social-location">none</content_attribute>
+-        <content_attribute id="social-contacts">none</content_attribute>
+-        <content_attribute id="money-purchasing">none</content_attribute>
+-        <content_attribute id="money-gambling">none</content_attribute>
+-    </content_rating>
++    <content_rating type="oars-1.1"/>
+     <developer_name>Horacio Daniel Ros</developer_name>
+     <url type="homepage">https://github.com/horaciodrs/TradeSim</url>
+     <url type="bugtracker">https://github.com/horaciodrs/TradeSim/issues</url>
+     <url type="help">https://github.com/horaciodrs/TradeSim/issues</url>
++    <url type="vcs-browser">https://github.com/horaciodrs/TradeSim/issues</url>
++    <launchable type="desktop-id">com.github.horaciodrs.tradesim.desktop</launchable>
+     <update_contact>horaciodrs@gmail.com</update_contact>
+     <screenshots>
+         <screenshot type="default">
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Use Freedesktop runtime instead of GNOME runtime
- Update runtime to 25.08
- fix appdata papercuts
- Add required libgee module
- Use x11 (insted of Wayland or fallback-x11) to fix a startup conflict